### PR TITLE
Updated Docker Image as implicit latest was not working.

### DIFF
--- a/doc/Dockerfile
+++ b/doc/Dockerfile
@@ -1,4 +1,4 @@
-from elasticsearch
+from elastic/elasticsearch:6.2.2
 MAINTAINER tim@sy-edm.com
 
 add elasticsearch.yml /etc/elasticsearch/elasticsearch.yml


### PR DESCRIPTION
Unsure as to why the :latest is implicitly not working, but the explicit :6.2.2 does.